### PR TITLE
Update the import paths for Caddy

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ SQLite requires `cgo`, so some modifications have to be made to the Caddy build 
 
 1. `go get` Caddy:
 
-        go get -u -v github.com/mholt/caddy
+        go get -u -v github.com/caddyserver/caddy
 
 2. Checkout Caddy `v0.11.5`:
 
-        cd $(go env GOPATH)/src/github.com/mholt/caddy
+        cd $(go env GOPATH)/src/github.com/caddyserver/caddy
         git checkout v0.11.5
 
 3. `go get` turnstile:

--- a/caddy.go
+++ b/caddy.go
@@ -9,8 +9,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/mholt/caddy"
-	"github.com/mholt/caddy/caddyhttp/httpserver"
+	"github.com/caddyserver/caddy"
+	"github.com/caddyserver/caddy/caddyhttp/httpserver"
 )
 
 // Turnstile is a Caddy middleware which records incoming traffic to a

--- a/collectors.go
+++ b/collectors.go
@@ -1,7 +1,7 @@
 package turnstile
 
 import (
-	"github.com/mholt/caddy/caddyfile"
+	"github.com/caddyserver/caddy/caddyfile"
 )
 
 var collectors = map[string]CollectorFactory{

--- a/sqlite.go
+++ b/sqlite.go
@@ -6,8 +6,8 @@ import (
 
 	_ "github.com/mattn/go-sqlite3"
 
-	"github.com/mholt/caddy"
-	"github.com/mholt/caddy/caddyfile"
+	"github.com/caddyserver/caddy"
+	"github.com/caddyserver/caddy/caddyfile"
 )
 
 type SQLiteCollector struct {


### PR DESCRIPTION
This pull request makes caddy-turnstile compatible with Caddy v1.0.1+ (see epicagency/caddy-expires#6 for reference) by updating the import paths for Caddy.